### PR TITLE
Potential fix for code scanning alert no. 10: Log Injection

### DIFF
--- a/src/halt.py
+++ b/src/halt.py
@@ -33,13 +33,17 @@ if not bot_token:
     logger.error("No BOT_TOKEN found in environment variables.")
 else:
     # Mask token in logs to prevent log injection and token exposure
-    # Sanitize token first by removing any control characters that could be used for log injection
-    sanitized_token = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', bot_token)
-    # Further remove risky newline and separator characters to prevent log injection
-    sanitized_token = re.sub(r'[\r\n\u2028\u2029]+', '', sanitized_token)
-    # Create masked version from sanitized token
+    # Define a strict sanitizer for logging user-derived values
+    def sanitize_for_log(s):
+        if not s:
+            return ''
+        # Remove all control characters, newlines, carriage returns, Unicode separators
+        # (matches ASCII control chars, \n, \r, Unicode line/paragraph separators)
+        return re.sub(r'[\x00-\x1f\x7f-\x9f\r\n\u2028\u2029]', '', s)
+    sanitized_token = sanitize_for_log(bot_token)
+    # Create masked version from sanitized token, ensuring segments are sanitized
     if len(sanitized_token) > 8:
-        masked_token = f"{sanitized_token[:4]}...{sanitized_token[-4:]}"
+        masked_token = f"{sanitize_for_log(sanitized_token[:4])}...{sanitize_for_log(sanitized_token[-4:])}"
     else:
         masked_token = "****"
     # Use %s placeholder to prevent any remaining injection risks


### PR DESCRIPTION
Potential fix for [https://github.com/dustfeather/device-activity-telegram-bot/security/code-scanning/10](https://github.com/dustfeather/device-activity-telegram-bot/security/code-scanning/10)

To fully mitigate log injection, sanitize user-controlled (`BOT_TOKEN`) environment variable to remove **all** control characters that could break log entries—especially within the masked segments used for logging. It is important to ensure that the masked token itself cannot contain any log-breaking or injection characters. The best fix is to strictly sanitize only the characters that are included in the log output (`masked_token`).  
Specifically:  
- When constructing `masked_token`, process the segments with a strict sanitization function that removes all control characters, newline, carriage return, Unicode separators, etc.  
- Optionally, replace any remaining unsafe characters with a safe placeholder (e.g., `*`).  
- Ensure that `masked_token` is always safe for logging, even in pathological cases.  
- All changes are confined to the log-entry logic around lines 37–46 of src/halt.py.

You may define a helper function, e.g., `sanitize_for_log(s: str) -> str`, above the token masking logic.  
No changes needed to imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce strict `sanitize_for_log` and sanitize masked BOT_TOKEN segments before logging to mitigate log injection.
> 
> - **Security/Logging (`src/halt.py`)**:
>   - Add `sanitize_for_log` to strip control chars, newlines, and Unicode separators from user-derived values.
>   - Sanitize `BOT_TOKEN` and its masked prefix/suffix segments before logging.
>   - Retain safe logging with `%s` placeholder for the masked token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b01475af4522798924d6ecac3ead4b872fd65bd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->