### PR TITLE
build: pin ruff <0.15 (format regression)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest>=8.3.4
 pytest-asyncio>=0.24.0
 
 # Code quality
-ruff>=0.6.0
+ruff>=0.6.0,<0.15
 mypy>=1.11.0
 
 # Development tools


### PR DESCRIPTION
## Summary

ruff 0.15.x has a regression where \`ruff format\` rewrites \`except (TimedOut, httpcore.ConnectTimeout):\` to \`except TimedOut, httpcore.ConnectTimeout:\` (removes the parens), producing invalid Python 3 syntax.

\`ruff format --check\` then flags the file as needing reformatting, which has been blocking the \`test\` job on every open Dependabot PR for the past month.

## Fix

Pin \`ruff<0.15\` in \`requirements-dev.txt\`. ruff 0.14.x handles the file correctly (\`1 file already formatted\`).

Once a fixed ruff release is out, this upper bound can be lifted.

## Verification

\`\`\`
$ ruff --version
ruff 0.14.4
$ ruff format --check src/ tests/
10 files already formatted
\`\`\`