### PR TITLE
chore(deps): cap ruff <0.15 and bump ipython >=9.13.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,11 +6,11 @@ pytest>=8.3.4
 pytest-asyncio>=0.24.0
 
 # Code quality
-ruff>=0.6.0,<0.16
+ruff>=0.6.0,<0.15
 mypy>=1.11.0
 
 # Development tools
-ipython>=8.12.3
+ipython>=9.13.0
 jupyter>=1.1.1
 nbconvert>=7.17.1
 


### PR DESCRIPTION
## Summary
- Caps `ruff` at `<0.15` to dodge the 0.15.x format regression that mangles `except (A, B):` into invalid Python 3 syntax `except A, B:` (hits `src/halt.py:73`).
- Applies the ipython floor bump from #31 (superseded by this PR, since main CI must be green first).

## Why
After yesterday's merges, main CI started failing on `ruff format --check src/halt.py`. Verified locally:
- `ruff 0.15.12` → "Would reformat: src/halt.py" (rewrites `except (TimedOut, httpcore.ConnectTimeout):` to invalid syntax)
- `ruff 0.14.14` → passes
ruff 0.16 isn't published yet, so `<0.15` is the right floor.

## Test plan
- [x] `ruff check src/ tests/` passes locally with capped ruff
- [x] `ruff format --check src/ tests/` passes locally with capped ruff
- [ ] CI green