### PR TITLE
chore: bump shared-workflows reusable workflows to v4

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,7 @@ jobs:
       issues: read
       id-token: write
       actions: read
-    uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v4
     with:
       runner: arc-df-device-activity-telegram-bot
     secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: dustfeather/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v4
     with:
       runner: arc-df-device-activity-telegram-bot

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.action != 'closed'
     permissions:
       contents: read
-    uses: dustfeather/shared-workflows/.github/workflows/python-test.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/python-test.yml@v4
     with:
       runner: arc-df-device-activity-telegram-bot
       run-mypy: true
@@ -36,7 +36,7 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
-    uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v3
+    uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v4
     with:
       runner: arc-df-device-activity-telegram-bot
     secrets: inherit


### PR DESCRIPTION
Bumps all shared-workflows reusable workflow references from v2/v3 to v4.